### PR TITLE
Add batch max size, rename processor, and re-order after interval proc

### DIFF
--- a/config/ast_defaults.yaml
+++ b/config/ast_defaults.yaml
@@ -53,5 +53,5 @@ pipelines:
   # detail.
   metrics/f5-datafabric:
     #receivers list are generated via the config helper script
-    processors: [batch, interval/f5-datafabric, attributes/f5-datafabric]
+    processors: [interval/f5-datafabric, attributes/f5-datafabric, batch/f5-datafabric]
     exporters: [otlp/f5-datafabric, debug/bigip]

--- a/services/otel_collector/defaults/bigip-scraper-config.yaml
+++ b/services/otel_collector/defaults/bigip-scraper-config.yaml
@@ -1,7 +1,8 @@
 receivers: ${file:/etc/otel-collector-config/receivers.yaml}
 
 processors:
-  batch:
+  batch/f5-datafabric:
+    send_batch_max_size: 8192
   # Only export data to f5 (if enabled) every 300s
   interval/f5-datafabric:
     interval: 300s


### PR DESCRIPTION
- Set max batch size on datafabric processor
- Fix processor order
- Rename datafabric batch processor to avoid conflicts