### PR TITLE
Update Grafana to 12.4.2 to address CVE-2026-27876

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,8 +42,8 @@ services:
       - 7lc_network
 
   grafana:
-    # grafana/grafana:v12.3.3
-    image: grafana/grafana@sha256:9e1e77ade304069aee3196e9a4f210830e96e80ce9a2640891eccc324b152faf
+    # grafana/grafana:12.4.2
+    image: grafana/grafana@sha256:83749231c3835e390a3144e5e940203e42b9589761f20ef3169c716e734ad505
     container_name: grafana
     restart: unless-stopped
     ports:


### PR DESCRIPTION
Bumps grafana/grafana from v12.3.3 to 12.4.2 to remediate the Grafana Remote Arbitrary Code Execution vulnerability (CVE-2026-27876).

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in this PR's description or commit message.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).